### PR TITLE
Add sides in cores of MultiplePointsClipper & MultipleRoundedPointsClipper

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,12 +40,45 @@ class _ClippersPageState extends State<ClippersPage> {
         padding: EdgeInsets.all(20),
         physics: BouncingScrollPhysics(),
         children: [
+          /// Multiple Points Clipper top only with height of points as 50
+          ClipPath(
+            clipper: MultiplePointsClipper(Sides.top, heightOfPoint: 50),
+            child: ContainerToClip(
+              Colors.red,
+              'Multiple Points Clipper Top Only',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
           /// Multiple Points Clipper bottom only with height of points as 50
           ClipPath(
             clipper: MultiplePointsClipper(Sides.bottom, heightOfPoint: 50),
             child: ContainerToClip(
               Colors.red,
               'Multiple Points Clipper Bottom Only',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
+          /// Multiple Points Clipper left only with height of points as 50
+          ClipPath(
+            clipper: MultiplePointsClipper(Sides.left, heightOfPoint: 50, numberOfPoints: 7),
+            child: ContainerToClip(
+              Colors.red,
+              'Multiple Points Clipper Left Only',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
+          /// Multiple Points Clipper right only with height of points as 50
+          ClipPath(
+            clipper: MultiplePointsClipper(Sides.right, heightOfPoint: 50, numberOfPoints: 7),
+            child: ContainerToClip(
+              Colors.red,
+              'Multiple Points Clipper Right Only',
             ),
           ),
 
@@ -62,10 +95,31 @@ class _ClippersPageState extends State<ClippersPage> {
 
           SizedBox(height: 20),
 
+          /// Multiple Points Clipper horizontal with number of points as 50
+          ClipPath(
+            clipper: MultiplePointsClipper(Sides.horizontal, numberOfPoints: 20),
+            child: ContainerToClip(
+              Colors.green,
+              'Multiple Points Clipper Vertical',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
+          /// Multiple Rounded Points Clipper top only with number of points as 30
+          ClipPath(
+            clipper: MultipleRoundedPointsClipper(Sides.top, numberOfPoints: 30),
+            child: ContainerToClip(
+              Colors.blue,
+              'Multiple Points Rounded Clipper Top Only',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
           /// Multiple Rounded Points Clipper bottom only with number of points as 30
           ClipPath(
-            clipper:
-                MultipleRoundedPointsClipper(Sides.bottom, numberOfPoints: 30),
+            clipper: MultipleRoundedPointsClipper(Sides.bottom, numberOfPoints: 30),
             child: ContainerToClip(
               Colors.blue,
               'Multiple Points Rounded Clipper Bottom Only',
@@ -74,13 +128,45 @@ class _ClippersPageState extends State<ClippersPage> {
 
           SizedBox(height: 20),
 
+          /// Multiple Rounded Points Clipper left only with number of points as 30
+          ClipPath(
+            clipper: MultipleRoundedPointsClipper(Sides.left, numberOfPoints: 13),
+            child: ContainerToClip(
+              Colors.blue,
+              'Multiple Points Rounded Clipper Left Only',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
+          /// Multiple Rounded Points Clipper right only with number of points as 30
+          ClipPath(
+            clipper: MultipleRoundedPointsClipper(Sides.right, numberOfPoints: 13),
+            child: ContainerToClip(
+              Colors.blue,
+              'Multiple Points Rounded Clipper Right Only',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
           /// Multiple Rounded Points Clipper vertical with height of points as 50
           ClipPath(
-            clipper:
-                MultipleRoundedPointsClipper(Sides.vertical, heightOfPoint: 50),
+            clipper: MultipleRoundedPointsClipper(Sides.vertical, heightOfPoint: 50),
             child: ContainerToClip(
               Colors.yellow,
               'Multiple Rounded Points Clipper Vertical',
+            ),
+          ),
+
+          SizedBox(height: 20),
+
+          /// Multiple Rounded Points Clipper horizontal with height of points as 50
+          ClipPath(
+            clipper: MultipleRoundedPointsClipper(Sides.horizontal, heightOfPoint: 40, numberOfPoints: 7),
+            child: ContainerToClip(
+              Colors.yellow,
+              'Multiple Rounded Points Clipper Horizontal',
             ),
           ),
 
@@ -121,8 +207,7 @@ class _ClippersPageState extends State<ClippersPage> {
 
           /// Directional Wave Clipper with vertical position as VerticalPosition.TOP
           ClipPath(
-            clipper:
-                DirectionalWaveClipper(verticalPosition: VerticalPosition.top),
+            clipper: DirectionalWaveClipper(verticalPosition: VerticalPosition.top),
             child: ContainerToClip(
               Colors.yellow,
               'Directional Wave Clipper Top Left',
@@ -133,8 +218,7 @@ class _ClippersPageState extends State<ClippersPage> {
 
           /// Directional Wave Clipper with horizontal position as HorizontalPosition.RIGHT
           ClipPath(
-            clipper: DirectionalWaveClipper(
-                horizontalPosition: HorizontalPosition.right),
+            clipper: DirectionalWaveClipper(horizontalPosition: HorizontalPosition.right),
             child: ContainerToClip(
               Colors.red,
               'Directional Wave Clipper Bottom Right',
@@ -146,8 +230,7 @@ class _ClippersPageState extends State<ClippersPage> {
           /// Directional Wave Clipper with vertical position as VerticalPosition.TOP  and  horizontal position as HorizontalPosition.RIGHT
           ClipPath(
             clipper: DirectionalWaveClipper(
-                verticalPosition: VerticalPosition.top,
-                horizontalPosition: HorizontalPosition.right),
+                verticalPosition: VerticalPosition.top, horizontalPosition: HorizontalPosition.right),
             child: ContainerToClip(
               Colors.green,
               'Directional Wave Clipper Top Right',
@@ -169,8 +252,7 @@ class _ClippersPageState extends State<ClippersPage> {
 
           /// Sin Cosine Wave Clipper with vertical position as VerticalPosition.TOP
           ClipPath(
-            clipper:
-                SinCosineWaveClipper(verticalPosition: VerticalPosition.top),
+            clipper: SinCosineWaveClipper(verticalPosition: VerticalPosition.top),
             child: ContainerToClip(
               Colors.yellow,
               'Sin Cosine Wave Clipper Top Left',
@@ -181,8 +263,7 @@ class _ClippersPageState extends State<ClippersPage> {
 
           /// Sin Cosine Wave with horizontal position as HorizontalPosition.RIGHT
           ClipPath(
-            clipper: SinCosineWaveClipper(
-                horizontalPosition: HorizontalPosition.right),
+            clipper: SinCosineWaveClipper(horizontalPosition: HorizontalPosition.right),
             child: ContainerToClip(
               Colors.red,
               'Sin Cosine Wave Clipper Bottom Right',
@@ -194,8 +275,7 @@ class _ClippersPageState extends State<ClippersPage> {
           /// Sin Cosine Wave Clipper with vertical position as VerticalPosition.TOP  and  horizontal position as HorizontalPosition.RIGHT
           ClipPath(
             clipper: SinCosineWaveClipper(
-                verticalPosition: VerticalPosition.top,
-                horizontalPosition: HorizontalPosition.right),
+                verticalPosition: VerticalPosition.top, horizontalPosition: HorizontalPosition.right),
             child: ContainerToClip(
               Colors.green,
               'Sin Cosine Wave Clipper Top Right',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -100,7 +100,7 @@ class _ClippersPageState extends State<ClippersPage> {
             clipper: MultiplePointsClipper(Sides.horizontal, numberOfPoints: 20),
             child: ContainerToClip(
               Colors.green,
-              'Multiple Points Clipper Vertical',
+              'Multiple Points Clipper Horizontal',
             ),
           ),
 

--- a/lib/clippers/multiple_points_clipper.dart
+++ b/lib/clippers/multiple_points_clipper.dart
@@ -22,32 +22,58 @@ class MultiplePointsClipper extends CustomClipper<Path> {
   final int numberOfPoints;
   final Sides side;
 
-  MultiplePointsClipper(this.side,
-      {this.heightOfPoint = 12, this.numberOfPoints = 16});
+  MultiplePointsClipper(this.side, {this.heightOfPoint = 12, this.numberOfPoints = 16});
 
   @override
   Path getClip(Size size) {
     Path path = Path();
-    path.lineTo(0, size.height);
     double x = 0.0;
-    double y = size.height;
-    double increment = size.width / numberOfPoints / 2;
+    double y = 0.0;
+    double incrementHeight = size.height / numberOfPoints / 2;
+    double incrementWidth = size.width / numberOfPoints / 2;
+
+    if (side == Sides.left || side == Sides.horizontal) {
+      while (y < size.height) {
+        x = (x != heightOfPoint) ? heightOfPoint : 0;
+        y += incrementHeight;
+        path.lineTo(x, y);
+      }
+    }
+
+    path.lineTo(0, size.height);
+
+    if (side == Sides.top || side == Sides.left || side == Sides.right || side == Sides.horizontal) {
+      path.lineTo(size.width, size.height);
+    }
 
     if (side == Sides.bottom || side == Sides.vertical) {
+      x = 0.0;
+      y = size.height;
       while (x < size.width) {
-        x += increment;
+        x += incrementWidth;
         y = (y == size.height) ? size.height - heightOfPoint : size.height;
         path.lineTo(x, y);
       }
     }
+
+    if (side == Sides.right || side == Sides.horizontal) {
+      x = size.width;
+      y = size.height;
+      while (y > 0) {
+        y -= incrementHeight;
+        x = (x == size.width) ? size.width - heightOfPoint : size.width;
+        path.lineTo(x, y);
+      }
+    }
+
     path.lineTo(size.width, 0.0);
 
     x = size.width;
     y = 0.0;
-    if (side == Sides.vertical) {
+    if (side == Sides.top || side == Sides.vertical) {
       while (x > 0) {
-        x -= increment;
-        y = (y == 0) ? 0 + heightOfPoint : 0;
+        x -= incrementWidth;
+        y = (y == 0) ? heightOfPoint : 0;
         path.lineTo(x, y);
       }
     }

--- a/lib/clippers/multiple_rounded_points_clipper.dart
+++ b/lib/clippers/multiple_rounded_points_clipper.dart
@@ -23,35 +23,58 @@ class MultipleRoundedPointsClipper extends CustomClipper<Path> {
   final int numberOfPoints;
   final Sides side;
 
-  MultipleRoundedPointsClipper(this.side,
-      {this.heightOfPoint = 12, this.numberOfPoints = 16}); // final Sides side;
+  MultipleRoundedPointsClipper(this.side, {this.heightOfPoint = 12, this.numberOfPoints = 16}); // final Sides side;
 
   @override
   Path getClip(Size size) {
     Path path = Path();
-    path.lineTo(0.0, size.height);
-    double x = 0;
-    double y = size.height;
+    double x = 0.0;
+    double y = 0.0;
+    double xControlPoint = size.width - heightOfPoint;
     double yControlPoint = size.height - heightOfPoint;
-    double increment = size.width / numberOfPoints;
+    double incrementHeight = size.height / numberOfPoints;
+    double incrementWidth = size.width / numberOfPoints;
+
+    if (side == Sides.left || side == Sides.horizontal) {
+      while (y < size.height) {
+        path.quadraticBezierTo(heightOfPoint, y + incrementHeight / 2, x, y + incrementHeight);
+        y += incrementHeight;
+      }
+    }
+
+    x = 0.0;
+    y = size.height;
+    path.lineTo(x, y);
+
+    if (side == Sides.top || side == Sides.left || side == Sides.right || side == Sides.horizontal) {
+      path.lineTo(size.width, size.height);
+    }
 
     if (side == Sides.bottom || side == Sides.vertical) {
       while (x < size.width) {
-        path.quadraticBezierTo(
-            x + increment / 2, yControlPoint, x + increment, y);
-        x += increment;
+        path.quadraticBezierTo(x + incrementWidth / 2, yControlPoint, x + incrementWidth, y);
+        x += incrementWidth;
       }
     }
 
-    path.lineTo(size.width, 0.0);
+    x = size.width;
 
-    if (side == Sides.vertical) {
+    if (side == Sides.right || side == Sides.horizontal) {
+      while (y > 0) {
+        path.quadraticBezierTo(xControlPoint, y - incrementHeight / 2, x, y - incrementHeight);
+        y -= incrementHeight;
+      }
+    }
+
+    path.lineTo(x, 0.0);
+
+    if (side == Sides.top || side == Sides.vertical) {
       while (x > 0) {
-        path.quadraticBezierTo(
-            x - increment / 2, heightOfPoint, x - increment, 0);
-        x -= increment;
+        path.quadraticBezierTo(x - incrementWidth / 2, heightOfPoint, x - incrementWidth, 0);
+        x -= incrementWidth;
       }
     }
+
     path.close();
     return path;
   }

--- a/lib/enum/enums.dart
+++ b/lib/enum/enums.dart
@@ -1,9 +1,13 @@
 part of 'package:custom_clippers/custom_clippers.dart';
 
 /// [Sides] is the enum which has two values and tells about the side.
+/// [Sides.top] is for the top side.
 /// [Sides.bottom] is for the bottom side.
+/// [Sides.right] is for the right side.
+/// [Sides.left] is for the left side.
 /// [Sides.vertical] is for the bottom and top sides.
-enum Sides { bottom, vertical }
+/// [Sides.horizontal] is for the right and left sides.
+enum Sides { top, bottom, right, left, vertical, horizontal }
 
 /// [MessageType] is the enum has two values and tells about the type of the
 /// message.


### PR DESCRIPTION
I have Added top, left, right, and horizontal sides in the cores of MultiplePointsClipper & MultipleRoundedPointsClipper.
```
enum Sides { top, bottom, right, left, vertical, horizontal }
```

And I have updated the example too. it looks like this :

![Screenshot_1658418626](https://user-images.githubusercontent.com/59434278/180259134-ce1709c2-6f48-425d-ab28-d76e04ef2a37.png)
![Screenshot_1658418629](https://user-images.githubusercontent.com/59434278/180259185-bc451cb1-4fc4-4466-b80a-e5e193169cb2.png)
![Screenshot_1658418631](https://user-images.githubusercontent.com/59434278/180259213-25b2faba-0b7d-4a69-a2de-43d78d4f7ffe.png)
![Screenshot_1658418637](https://user-images.githubusercontent.com/59434278/180259235-25d72832-1572-45f3-9258-8787e9daafa3.png)
![Screenshot_1658418639](https://user-images.githubusercontent.com/59434278/180259312-bef63378-71f9-4505-a0a6-a39f9cb0baca.png)
![Screenshot_1658418797](https://user-images.githubusercontent.com/59434278/180259293-aaf1de57-c22c-401c-9672-c9b29ee64aba.png)

Hopefully, you are welcome with these commits for the pull request.
Thanks!


